### PR TITLE
Remove Sergio Lopez from Architecture Committee

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ The current Architecture Committee members are:
 * Michael Zhao    ([@michael2012z](https://github.com/michael2012z))  ARM
 * Robert Bradford ([@rbradford](https://github.com/rbradford))     Intel
 * Samuel Ortiz    ([@sameo](https://github.com/sameo))         Apple
-* Sergio Lopez    ([@slp](https://github.com/slp))           Red Hat
 
 ### Elections
 


### PR DESCRIPTION
Remove myself from the Architecture Committee. I honestly don't have
the time that Cloud Hypervisor deserves to be invested on it, so I
think the right thing for me to do here is to resign from the
Architecture Committee.

Signed-off-by: Sergio Lopez <slp@redhat.com>